### PR TITLE
debounced challenge channel updates

### DIFF
--- a/src/discord/events/interaction/commands/submit.ts
+++ b/src/discord/events/interaction/commands/submit.ts
@@ -1,6 +1,7 @@
 import { ApplicationCommandOptionTypes } from 'discord.js/typings/enums';
 import { ChatInputCommandDefinition, PopulatedCommandInteraction } from '../interaction';
 import { getCtfByGuildContext } from '../../../util/ResourceManager';
+import { debounceChallengeChannelUpdates } from '../../../util/UpdateDebouncer';
 
 export default {
   name: 'submit',
@@ -18,7 +19,12 @@ export default {
     const ctf = await getCtfByGuildContext(interaction.guild);
     if (!ctf) throw new Error('this guild does not belong to a ctf');
 
-    const flag = ctf.getFlag(interaction.options.getString('flag', true));
+    const flag = await ctf.getFlag(interaction.options.getString('flag', true));
+    if (!flag) throw new Error('Invalid flag. Checking for trailing spaces and typos.');
+    const challenge = await flag.getChallenge();
+
+    // update the challenge channels, but in a debounced fashion
+    debounceChallengeChannelUpdates(challenge, interaction.client);
 
     return 'to be implemented';
   },

--- a/src/discord/events/interaction/interaction.ts
+++ b/src/discord/events/interaction/interaction.ts
@@ -5,7 +5,6 @@ import {
   Client,
   CommandInteraction,
   Interaction,
-  UserContextMenuInteraction,
 } from 'discord.js';
 import { category, challenge, ctf } from './commands';
 import { embedify, logger } from '../../../log';

--- a/src/discord/util/UpdateDebouncer.ts
+++ b/src/discord/util/UpdateDebouncer.ts
@@ -1,0 +1,24 @@
+import { Challenge } from '../../database/models/Challenge';
+import { refreshChallenge } from "../hooks/ChallengeHooks";
+import { Client } from "discord.js";
+
+// a hashmap from challenge ids to their timeout ID
+const mapping = new Map<number, NodeJS.Timeout>();
+
+// this function will trigger an update to challenge channels... but no more than
+// once every two minutes
+export function debounceChallengeChannelUpdates(challenge: Challenge, client: Client<true>) {
+  const timeout = mapping.get(challenge.id);
+
+  // if there's currently a timeout for this challenge, just ignore for now
+  if (timeout) return;
+
+  // otherwise, kick off the update to happen in two minutes
+  mapping.set(
+    challenge.id,
+    setTimeout(() => {
+      mapping.delete(challenge.id);
+      void refreshChallenge(challenge, client);
+    }, 1000 * 120),
+  );
+}


### PR DESCRIPTION
Rather than having a periodic refresh, this just makes it so that challenge channels will only be updated when somebody actually captures a flag, but even then, limited to at most once every two minutes.

Closes #29, minus the scoreboard stuff which will be tackled when scoreboards are tackled (soon).